### PR TITLE
Add nullcheck to breadcrumb metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /captures
 tmp
 .externalNativeBuild
+CMakeFiles
+CMakeCache.txt

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -5,6 +5,14 @@ repositories {
     google()
 }
 
+allprojects {
+    repositories {
+        flatDir {
+            dirs 'libs'
+        }
+    }
+}
+
 android {
     compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
     buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
@@ -68,6 +76,7 @@ dependencies {
     implementation "com.android.support:support-annotations:$supportLibVersion"
     implementation "com.bugsnag:bugsnag-android-ndk:1.1.2"
     implementation "com.bugsnag:bugsnag-android:4.2.2"
+//    compile (name: "ndk-release", ext: "aar")
 }
 
 apply plugin: 'com.bugsnag.android.gradle'

--- a/ndk/src/main/jni/bugsnag_ndk_report.c
+++ b/ndk/src/main/jni/bugsnag_ndk_report.c
@@ -814,9 +814,11 @@ void bsg_populate_breadcrumbs(JNIEnv *env, bsg_event *event) {
                 const char* key = (*env)->GetStringUTFChars(env, key_str, JNI_FALSE);
 
                 jstring value_str = bsg_get_item_from_map(env, meta_data_value, key_str);
-                const char* value = (*env)->GetStringUTFChars(env, value_str, JNI_FALSE);
 
-                bugsnag_object_set_string(json_value_get_object(crumb->metadata), key, value);
+                if (value_str != NULL) {
+                    const char* value = (*env)->GetStringUTFChars(env, value_str, JNI_FALSE);
+                    bugsnag_object_set_string(json_value_get_object(crumb->metadata), key, value);
+                }
 
                 (*env)->DeleteLocalRef(env, key_str);
                 (*env)->DeleteLocalRef(env, value_str);


### PR DESCRIPTION
Adds a null check when reading breadcrumb metadata values.

Also updates build.gradle file to allow testing of local changes to the NDK library by depending on an AAR.