### PR TITLE
Retain previously added breadcrumbs whenever a new breadcrumb is added

### DIFF
--- a/ndk/src/main/jni/deps/bugsnag/report.c
+++ b/ndk/src/main/jni/deps/bugsnag/report.c
@@ -101,8 +101,6 @@ void bugsnag_event_add_breadcrumb(bsg_event *event, bsg_breadcrumb *crumb) {
     json_value_free(old_crumb->metadata);
     free(old_crumb);
     for (int i = 0; i < length - 1; i++) {
-      bsg_breadcrumb *crumb1 = event->breadcrumbs[i];
-      bsg_breadcrumb *crumb2 = event->breadcrumbs[i + 1];
       event->breadcrumbs[i] = event->breadcrumbs[i + 1];
     }
     event->breadcrumbs[length - 1] = crumb;


### PR DESCRIPTION
This changeset avoids clearing all breadcrumbs everytime a new breadcrumb is added, by omitting a call to `bugsnag_event_clear_breadcrumbs`. Previously this method freed memory, then allocated new memory for each breadcrumb.

Reducing this churn by retaining previously added values will partially address #10, which is caused by multiple threads attempting to free/allocate memory at the same time. I've found that running the [reproduction case](https://github.com/bugsnag/bugsnag-android-ndk/tree/segfault-repro-case) results in less frequent signals when this fix is applied.

One concern with this change is that we should be careful it hasn't introduced any memory leaks. I believe the `bugsnag_event_add_breadcrumb` method was freeing the required memory in the first place so `bugsnag_event_clear_breadcrumbs` wasn't necessary, but it would be good to confirm this.