### PR TITLE
Make signing plugin optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ This process is a little ridiculous...
 -   Build and upload the new version
 
     ```shell
-    ./gradlew clean assemble && ./gradlew publish
+    ./gradlew clean assemble -Preleasing=true && ./gradlew publish -Preleasing=true
     ```
 
 -   "Promote" the release build on Maven Central

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ endif
 	@git commit -am "Release v$(VERSION)"
 	@git tag v$(VERSION)
 	@git push origin master v$(VERSION)
-	@./gradlew clean assemble uploadArchives bintrayUpload
+	@./gradlew clean assemble uploadArchives bintrayUpload -Preleasing=true

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ ext {
 
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'signing'
 
 
 def target = 'ndk/build/outputs/aar/ndk-release.aar'
@@ -36,11 +35,15 @@ model {
     }
 }
 
-signing {
-    if (file(target).exists())
-        sign file(target)
-    if (file(pomPath).exists())
-        sign file(pomPath)
+if (project.hasProperty("releasing")) {
+    apply plugin: 'signing'
+
+    signing {
+        if (file(target).exists())
+            sign file(target)
+        if (file(pomPath).exists())
+            sign file(pomPath)
+    }
 }
 
 publishing {


### PR DESCRIPTION
Makes applying the signing plugin optional, which avoids build errors due to missing signatory information when GPG signing has not been setup on a machine.

Signing is now enabled by adding `Preleasing=true` on the command line.

Fixes #8 