### PR TITLE
Use bugsnag fork of ndk repo for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 # see https://github.com/travis-ci/travis-ci/issues/8874
   - yes | sdkmanager "platforms;android-27"
   - echo y | sdkmanager "cmake;3.6.4111459"
-  - git clone --depth 1 https://github.com/urho3d/android-ndk.git $HOME/android-ndk-root
+  - git clone --depth 1 https://github.com/bugsnag/android-ndk $HOME/android-ndk-root
   - export ANDROID_NDK_HOME=$HOME/android-ndk-root
 
 env:


### PR DESCRIPTION
Travis doesn't have a predefined image for the NDK so this needs to be cloned to build the repo. This updates CI to use our fork.