### PR TITLE
Update NDK CI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ before_install:
 # see https://github.com/travis-ci/travis-ci/issues/8874
   - yes | sdkmanager "platforms;android-27"
   - echo y | sdkmanager "cmake;3.6.4111459"
-  - git clone --depth 1 https://github.com/bugsnag/android-ndk $HOME/android-ndk-root
-  - export ANDROID_NDK_HOME=$HOME/android-ndk-root
+  - echo y | sdkmanager "ndk-bundle"
+  - echo y | sdkmanager "lldb;3.1"
+
 
 env:
   matrix:


### PR DESCRIPTION
Installs the latest version of the NDK using the `sdkmanager` tool, rather than cloning an old git repo.