### PR TITLE
Build project with older version of ndk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,21 @@ android:
     - extra-google-m2repository
     - extra-android-m2repository
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
+
 before_install:
-# see https://github.com/travis-ci/travis-ci/issues/8874
+  - ./install_ndk.sh
+  # see https://github.com/travis-ci/travis-ci/issues/8874
   - yes | sdkmanager "platforms;android-27"
   - echo y | sdkmanager "cmake;3.6.4111459"
-  - echo y | sdkmanager "ndk-bundle"
   - echo y | sdkmanager "lldb;3.1"
-
 
 env:
   matrix:

--- a/install_ndk.sh
+++ b/install_ndk.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+export OS_VERSION='linux-x86_64'
+export NDK_VERSION='r16b'
+
+echo "Downloading NDK, this will take a while..."
+wget -q https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-${OS_VERSION}.zip
+
+echo "Unzipping NDK, this will take a while..."
+unzip -q android-ndk-${NDK_VERSION}-${OS_VERSION}.zip
+
+echo "Copying to ndk-bundle"
+mv android-ndk-${NDK_VERSION} $ANDROID_HOME/ndk-bundle
+
+export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+export ANDROID_NDK=$ANDROID_HOME/ndk-bundle
+
+# add to PATH
+export PATH=${PATH}:${ANDROID_NDK_HOME}

--- a/ndk/build.gradle
+++ b/ndk/build.gradle
@@ -17,7 +17,7 @@ android {
         // Note minSdkVersion must be >=21 for 64 bit architectures
         minSdkVersion Integer.parseInt(project.ANDROID_MIN_SDK_VERSION)
         ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+            abiFilters 'arm64-v8a', 'armeabi-v7a', 'armeabi', 'x86', 'x86_64'
         }
     }
 


### PR DESCRIPTION
## Goal

Builds the project with NDK r16b, which maintains armeabi support - a requirement for users stuck on older versions. This requires a script that downloads the NDK bundle onto the machine. This change also caches gradle to speed up the CI build.

## Changeset

### Added

- Gradle caching
- NDK download bash script

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
